### PR TITLE
Allow extracting text from instanced scenes

### DIFF
--- a/babel_godot.py
+++ b/babel_godot.py
@@ -4,7 +4,7 @@ import re
 __version__ = '0.1'
 
 
-_godot_node = re.compile(r'^\[node name="([^"]+)" type="([^"]+)"')
+_godot_node = re.compile(r'^\[node name="([^"]+)" (:?type="([^"]+)")?')
 _godot_property_str = re.compile(r'^([A-Za-z0-9_]+)\s*=\s*(".+)$')
 
 
@@ -66,6 +66,10 @@ def extract_godot_scene(fileobj, keywords, comment_tags, options):
         if match:
             # Store which kind of node we're in
             current_node_type = match.group(2)
+            #instanced packed scenes don't have the type field,
+            #change current_node_type to empty string
+            current_node_type = current_node_type \
+                    if current_node_type is not None else ""
         elif line.startswith('['):
             # We're no longer in a node
             current_node_type = None


### PR DESCRIPTION
I found that in order to extract text from exports in packed scenes the following changes are necessary.

The problem is packed scenes in tscn files don't have the _type=_ property so they are not accepted by the regular expression that deals with nodes.

For instance, this packed scene with this property wouldn't be extracted:
```
[node name="LeavePortal" parent="." index="8" instance=ExtResource( 4 )]
text = "leave"
```

I make this PR in case you find it useful, thank you for your work!