### PR TITLE
Handle multi-line strings in scenes and resources

### DIFF
--- a/babel_godot.py
+++ b/babel_godot.py
@@ -9,11 +9,9 @@ _godot_property_str = re.compile(r'^([A-Za-z0-9_]+)\s*=\s*(".+)$')
 
 
 def _godot_unquote(string):
-    if string[0] != '"' or string[-1] != '"':
-        return None
     result = []
     escaped = False
-    for c in string[1:-1]:
+    for i, c in enumerate(string):
         if escaped:
             if c == '\\':
                 result.append('\\')
@@ -26,9 +24,11 @@ def _godot_unquote(string):
         else:
             if c == '\\':
                 escaped = True
+            elif c == '"':
+                return ''.join(result), string[i + 1:]
             else:
                 result.append(c)
-    return ''.join(result)
+    return ''.join(result), None
 
 
 def extract_godot_scene(fileobj, keywords, comment_tags, options):
@@ -82,7 +82,7 @@ def extract_godot_scene(fileobj, keywords, comment_tags, options):
                 value = match.group(2)
                 keyword = check_translate_property(property)
                 if keyword:
-                    value = _godot_unquote(value)
+                    value, remainder = _godot_unquote(value[1:])
                     if value is not None:
                         yield (lineno, keyword, [value], [])
 
@@ -121,6 +121,6 @@ def extract_godot_resource(fileobj, keywords, comment_tags, options):
             value = match.group(2)
             keyword = check_translate_property(property)
             if keyword:
-                value = _godot_unquote(value)
+                value, remainder = _godot_unquote(value[1:])
                 if value is not None:
                     yield (lineno, keyword, [value], [])

--- a/babel_godot.py
+++ b/babel_godot.py
@@ -83,8 +83,14 @@ def extract_godot_scene(fileobj, keywords, comment_tags, options):
                 keyword = check_translate_property(property)
                 if keyword:
                     value, remainder = _godot_unquote(value[1:])
-                    if value is not None:
+                    if remainder is None:  # Un-terminated string
+                        raise NotImplementedError(
+                            "Multi-line strings are not yet supported"
+                        )
+                    elif not remainder.strip():
                         yield (lineno, keyword, [value], [])
+                    else:
+                        raise ValueError("Trailing data after string")
 
 
 def extract_godot_resource(fileobj, keywords, comment_tags, options):
@@ -122,5 +128,11 @@ def extract_godot_resource(fileobj, keywords, comment_tags, options):
             keyword = check_translate_property(property)
             if keyword:
                 value, remainder = _godot_unquote(value[1:])
-                if value is not None:
+                if remainder is None:  # Un-terminated string
+                    raise NotImplementedError(
+                        "Multi-line strings are not yet supported"
+                    )
+                elif not remainder.strip():
                     yield (lineno, keyword, [value], [])
+                else:
+                    raise ValueError("Trailing data after string")

--- a/testproject/World.tscn
+++ b/testproject/World.tscn
@@ -13,7 +13,8 @@ anchor_right = 0.5
 anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
-text = "Hello from scene"
+text = "From scene:
+Hello!"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/testproject/translations.pot
+++ b/testproject/translations.pot
@@ -21,8 +21,10 @@ msgstr ""
 msgid "Hello from script"
 msgstr ""
 
-#: World.tscn:16
-msgid "Hello from scene"
+#: World.tscn:17
+msgid ""
+"From scene:\n"
+"Hello!"
 msgstr ""
 
 #: protagonist.tres:9


### PR DESCRIPTION
Handle a multi-line string, add one to the testproject.

This doesn't fix the array case #6.

This should correctly deal with escaped quotation marks contrary to #9. It changes behavior a little, in that errors will be raised on incorrect content where previously such content would be ignored.