### PR TITLE
Allow other types in an array

### DIFF
--- a/babel_godot.py
+++ b/babel_godot.py
@@ -78,7 +78,8 @@ class ArrayReader(object):
                     self.string = None
                     i = 0
             else:
-                raise ValueError("Unexpected character %r" % (c,))
+                print("Unexpected char %r" % (c,))
+                #raise ValueError("Unexpected character %r" % (c,))
 
         raise ValueError("Unterminated array")
 

--- a/babel_godot.py
+++ b/babel_godot.py
@@ -63,9 +63,7 @@ class ArrayReader(object):
         i = 0
         while i < len(string):
             c = string[i]
-            if c in ' \t,':
-                i = i + 1
-            elif c == ']':
+            if c == ']':
                 return string[i + 1:]
             elif c == '"':
                 self.string = StringReader(lineno)
@@ -78,9 +76,7 @@ class ArrayReader(object):
                     self.string = None
                     i = 0
             else:
-                print("Unexpected char %r" % (c,))
                 i = i + 1
-                #raise ValueError("Unexpected character %r" % (c,))
 
         raise ValueError("Unterminated array")
 

--- a/babel_godot.py
+++ b/babel_godot.py
@@ -79,6 +79,7 @@ class ArrayReader(object):
                     i = 0
             else:
                 print("Unexpected char %r" % (c,))
+                i = i + 1
                 #raise ValueError("Unexpected character %r" % (c,))
 
         raise ValueError("Unterminated array")


### PR DESCRIPTION
Just had an use case where an `OptionButton` creates an array of various types, not just strings. So to support this I would just ignore any other types instead of throwing an error.

And example of the items of `OptionButton`:
```gdscript
items = [ "LANG_EN", null, false, 0, null, "LANG_DE", null, false, 1, null, "LANG_JP", null, false, 2, null ]
```